### PR TITLE
Develop

### DIFF
--- a/Gem1.gemspec
+++ b/Gem1.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.authors = "Jordon Bedwell"
   spec.email = "envygeeks@gmail.com"
 
-  spec.add_dependency("activerecord", ">= 3.2", "< 4.2")
+  spec.add_dependency("activerecord", ">= 3.2", "<= 4.2")
   spec.add_development_dependency("envygeeks-coveralls", "~> 0.2")
   spec.add_development_dependency("luna-rspec-formatters", "~> 1.2")
   spec.add_development_dependency("rspec", "~> 3.0")

--- a/spec/lib/active_record_mocks_spec.rb
+++ b/spec/lib/active_record_mocks_spec.rb
@@ -130,10 +130,10 @@ describe ActiveRecordMocks do
         t.belongs_to :foo
       end
 
-      expect(t2.reflections[:foo]).not_to be_nil
-      expect(t1.reflections[:bars]).not_to be_nil
-      expect(t1.reflections[:bars].macro).to eq :has_many
-      expect(t2.reflections[:foo].macro).to eq :belongs_to
+      expect(t2.reflect_on_association(:foo)).not_to be_nil
+      expect(t1.reflect_on_association(:bars)).not_to be_nil
+      expect(t1.reflect_on_association(:bars).macro).to eq :has_many
+      expect(t2.reflect_on_association(:foo).macro).to eq :belongs_to
     end
   end
 

--- a/spec/lib/active_record_mocks_spec.rb
+++ b/spec/lib/active_record_mocks_spec.rb
@@ -138,7 +138,7 @@ describe ActiveRecordMocks do
   end
 
   it "creates a module using specified parent class" do
-    class TestBase < ActiveRecord::Base;  end
+    class TestBase < ActiveRecord::Base; self.abstract_class = true; end
     with_mocked_tables do |m|
       t1 = m.create_table do |t|
         t.parent_class :TestBase


### PR DESCRIPTION
A few tweaks to support ActiveRecord 4.2 now that Lanes is moving to it.  I also found an omission on the parent_class spec, where it needs to be set as an abstract_class.