### PR TITLE
Handle pre-existing classes gracefully

### DIFF
--- a/lib/active_record_mocks/mock/table.rb
+++ b/lib/active_record_mocks/mock/table.rb
@@ -129,13 +129,11 @@ module ActiveRecordMocks
 
       private
       def setup_model!
-        Object.const_set(model_name, \
-            Class.new(parent_class)).tap do |o|
-
-          o.table_name = table_name
-          setup_includes(o)
-          run_model_methods(o)
-        end
+        definition = Object.const_defined?(model_name) ? Object.const_get(model_name) :
+                       Object.const_set(model_name, Class.new(parent_class))
+        definition.table_name = table_name
+        setup_includes(definition)
+        run_model_methods(definition)
       end
 
       private

--- a/spec/lib/active_record_mocks_spec.rb
+++ b/spec/lib/active_record_mocks_spec.rb
@@ -149,4 +149,15 @@ describe ActiveRecordMocks do
     end
   end
 
+  it "doesn't complain when the class already exists" do
+    class ALongTableNameThatDoesntExist < ActiveRecord::Base; end
+    with_mocked_tables do |m|
+      m.create_table do |t|
+        t.model_name :ALongTableNameThatDoesntExist
+      end
+    end
+    # even though the class existed beforehand, we should still cleanup
+    expect(Object.const_defined?(:ALongTableNameThatDoesntExist)).to be(false)
+  end
+
 end


### PR DESCRIPTION
My use case for this is probably fairly unique, but it doesn't hurt to support it.

I have base class that uses `inherited` to detect when other classes inherit from it.  In the method, I check the class name and perform various actions with it.  

Unfortunately this breaks when using `active_record_mocks`  The class is created using Class.new, and then assigned to a constant.  Per the Ruby docs (and tests), a class created by using Class.new doesn't have a name. It only gains a name once it's assigned to a constant.  So what ends up happing is that the class is created, it fires the parent class's `inherited` callback (while it has no name), and then is assigned to a constant where it gains a name.

To work around this I can create the class myself before hand and then call active_record_mocks' `create_table` to configure it and create the db table.  But then active_record_mocks causes ruby to complain about `constant already exists`